### PR TITLE
Adjustments to patch_drop

### DIFF
--- a/api/src/metadata_json.rs
+++ b/api/src/metadata_json.rs
@@ -74,8 +74,6 @@ impl MetadataJson {
             external_url: Set(payload.external_url),
         };
 
-        // let metadata_json = metadata_json_active_model.insert(conn).await?;
-
         let metadata_json = MetadataJsons::insert(metadata_json_active_model)
             .on_conflict(
                 OnConflict::column(MetadataJsonColumn::CollectionId)


### PR DESCRIPTION
## Changes
- Allow for updating seller fee basis points and creators or falling back to the previous value.
- Before metadata json was required to trigger the update. Now blockchain transaction sent without requiring metadata json.