### PR TITLE
make address option but unwrap to string::new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,8 +2109,8 @@ dependencies = [
 
 [[package]]
 name = "holaplex-hub-core"
-version = "0.1.0"
-source = "git+https://github.com/holaplex/hub-core?branch=stable#b1c65dd6c2b9d8b5c940584ad43c539f4d9130a5"
+version = "0.2.1"
+source = "git+https://github.com/holaplex/hub-core?branch=stable#c8eaef51ea8729686a1d74e2e8d9fc1a14f4dcb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2143,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "holaplex-hub-core-build"
-version = "0.1.0"
-source = "git+https://github.com/holaplex/hub-core?branch=stable#b1c65dd6c2b9d8b5c940584ad43c539f4d9130a5"
+version = "0.2.1"
+source = "git+https://github.com/holaplex/hub-core?branch=stable#c8eaef51ea8729686a1d74e2e8d9fc1a14f4dcb8"
 dependencies = [
  "anyhow",
  "dotenv",
@@ -2162,8 +2162,8 @@ dependencies = [
 
 [[package]]
 name = "holaplex-hub-core-schemas"
-version = "0.1.0"
-source = "git+https://github.com/holaplex/hub-core?branch=stable#b1c65dd6c2b9d8b5c940584ad43c539f4d9130a5"
+version = "0.2.1"
+source = "git+https://github.com/holaplex/hub-core?branch=stable#c8eaef51ea8729686a1d74e2e8d9fc1a14f4dcb8"
 dependencies = [
  "holaplex-hub-core-build",
  "prost",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -46,13 +46,13 @@ strum = { version = "0.24.1", features = ["derive"] }
 
 [dependencies.hub-core]
 package = "holaplex-hub-core"
-version = "0.1.0"
+version = "0.2.1"
 git = "https://github.com/holaplex/hub-core"
 branch = "stable"
 features = ["kafka", "credits", "asset_proxy"]
 
 [build-dependencies.hub-core-build]
 package = "holaplex-hub-core-build"
-version = "0.1.0"
+version = "0.2.1"
 git = "https://github.com/holaplex/hub-core"
 branch = "stable"

--- a/api/src/objects/wallet.rs
+++ b/api/src/objects/wallet.rs
@@ -8,7 +8,7 @@ use crate::{entities::collection_mints, AppContext};
 pub struct Wallet {
     /// A blockchain wallet address is a unique identifier that represents a destination for transactions on a blockchain network. It is a string of alphanumeric characters that can be used to receive and send digital assets, such as cryptocurrencies, on the blockchain network.
     #[graphql(external)]
-    pub address: String,
+    pub address: Option<String>,
 }
 
 #[ComplexObject]
@@ -24,7 +24,7 @@ impl Wallet {
         } = ctx.data::<AppContext>()?;
 
         collection_mints_owner_loader
-            .load_one(self.address.clone())
+            .load_one(self.address.clone().unwrap_or(String::new()))
             .await
     }
 }

--- a/api/src/queries/wallet.rs
+++ b/api/src/queries/wallet.rs
@@ -17,6 +17,8 @@ impl Query {
         _ctx: &Context<'_>,
         #[graphql(key)] address: String,
     ) -> Result<Wallet> {
-        Ok(Wallet { address })
+        Ok(Wallet {
+            address: Some(address),
+        })
     }
 }


### PR DESCRIPTION
Update `address` to option due to the following schema mismatch.

```text
WARN: The following build errors occurred:
EXTERNAL_TYPE_MISMATCH: Type of field "Wallet.address" is incompatible across subgraphs (where marked 
@external): it has type "String" in subgraph "hub-treasuries" but type "String!" in subgraph "hub-nfts"
```