### PR TITLE
Creator Validations and No Credit Error Messages

### DIFF
--- a/api/src/mutations/mint.rs
+++ b/api/src/mutations/mint.rs
@@ -357,7 +357,7 @@ async fn submit_pending_deduction(
         },
     };
 
-    let deduction_id = id.ok_or(Error::new("failed to generate credits deduction id"))?;
+    let deduction_id = id.ok_or(Error::new("Organization does not have enough credits"))?;
 
     let mut mint: collection_mints::ActiveModel = mint_model.into();
     mint.credits_deduction_id = Set(Some(deduction_id.0));

--- a/api/src/mutations/transfer.rs
+++ b/api/src/mutations/transfer.rs
@@ -173,7 +173,7 @@ async fn submit_pending_deduction(
         },
     };
 
-    let deduction_id = id.ok_or(Error::new("failed to generate credits deduction id"))?;
+    let deduction_id = id.ok_or(Error::new("Organization does not have enough credits"))?;
 
     let nft_transfer_model = nft_transfers::Entity::find_by_id(transfer_id)
         .one(db.get())


### PR DESCRIPTION
## Changes
- On Solana, validate only the project treasury wallet can be set to verified.
- Royalty shares of creators must equal a 100
- Adjust error messages of no credits.