### PR TITLE
Skip serializing optional metadata json fields

### DIFF
--- a/api/src/objects/metadata_json.rs
+++ b/api/src/objects/metadata_json.rs
@@ -95,10 +95,14 @@ pub struct MetadataJsonInput {
     pub symbol: String,
     pub description: String,
     pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub animation_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collection: Option<Collection>,
     pub attributes: Vec<Attribute>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<Property>,
 }
 


### PR DESCRIPTION
Optional fields should be skipped instead of writing them as null
![image](https://github.com/holaplex/hub-nfts/assets/45506001/ba557c35-57db-4061-9db1-236610e53868)
