### PR TITLE
Query mint by ID

### DIFF
--- a/api/src/dataloaders/update_histories.rs
+++ b/api/src/dataloaders/update_histories.rs
@@ -37,7 +37,7 @@ impl DataLoader<Uuid> for UpdateMintHistoryLoader {
                 acc.entry(history.mint_id).or_insert_with(Vec::new);
 
                 acc.entry(history.mint_id)
-                    .and_modify(|update_histories| update_histories.push(history.into()));
+                    .and_modify(|update_histories| update_histories.push(history));
 
                 acc
             }))

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -33,8 +33,7 @@ use crate::{
         Attribute, CreationStatus as NftCreationStatus, DropCreation, File, Metadata,
         MintCollectionCreation, MintCreation, MintOwnershipUpdate, MintedTokensOwnershipUpdate,
         NftEventKey, NftEvents, SolanaCollectionPayload, SolanaCompletedMintTransaction,
-        SolanaCompletedTransferTransaction, SolanaMintPayload, SolanaNftEventKey,
-        SolanaUpdatedMintPayload, TreasuryEventKey,
+        SolanaCompletedTransferTransaction, SolanaMintPayload, SolanaNftEventKey, TreasuryEventKey,
     },
     Actions, Services,
 };

--- a/api/src/mutations/mint.rs
+++ b/api/src/mutations/mint.rs
@@ -496,6 +496,9 @@ impl Mutation {
         })
     }
 
+    /// This mutation updates a mint.
+    /// # Errors
+    /// If the mint cannot be saved to the database or fails to be emitted for submission to the desired blockchain, the mutation will result in an error.
     pub async fn update_mint(
         &self,
         ctx: &Context<'_>,
@@ -651,6 +654,9 @@ impl Mutation {
         })
     }
 
+    /// This mutation retries updating a mint that failed by providing the ID of the `update_history`.
+    /// # Errors
+    /// If the mint cannot be saved to the database or fails to be emitted for submission to the desired blockchain, the mutation will result in an error.
     pub async fn retry_update_mint(
         &self,
         ctx: &Context<'_>,

--- a/api/src/objects/project.rs
+++ b/api/src/objects/project.rs
@@ -25,6 +25,7 @@ impl Project {
     }
 
     /// Look up a drop associated with the project by its ID.
+    #[graphql(deprecation = "Use `drop` root query field instead")]
     async fn drop(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<Drop>> {
         let AppContext { drop_loader, .. } = ctx.data::<AppContext>()?;
 
@@ -54,6 +55,8 @@ impl Project {
         project_collections_loader.load_one(self.id).await
     }
 
+    /// Look up a collection associated with the project by its ID.
+    #[graphql(deprecation = "Use `collection` root query field instead")]
     async fn collection(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<Collection>> {
         let AppContext {
             project_collection_loader,

--- a/api/src/queries/collection.rs
+++ b/api/src/queries/collection.rs
@@ -1,0 +1,20 @@
+use async_graphql::{Context, Object, Result};
+use hub_core::uuid::Uuid;
+
+use crate::{objects::Collection, AppContext};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Query;
+
+#[Object(name = "CollectionQuery")]
+impl Query {
+    /// Look up a `collection` by its ID.
+    async fn collection(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<Collection>> {
+        let AppContext {
+            project_collection_loader,
+            ..
+        } = ctx.data::<AppContext>()?;
+
+        project_collection_loader.load_one(id).await
+    }
+}

--- a/api/src/queries/drop.rs
+++ b/api/src/queries/drop.rs
@@ -1,0 +1,17 @@
+use async_graphql::{Context, Object, Result};
+use hub_core::uuid::Uuid;
+
+use crate::{objects::Drop, AppContext};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Query;
+
+#[Object(name = "DropQuery")]
+impl Query {
+    /// Look up a `drop` by its ID.
+    async fn drop(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<Drop>> {
+        let AppContext { drop_loader, .. } = ctx.data::<AppContext>()?;
+
+        drop_loader.load_one(id).await
+    }
+}

--- a/api/src/queries/mint.rs
+++ b/api/src/queries/mint.rs
@@ -1,0 +1,20 @@
+use async_graphql::{Context, Object, Result};
+use hub_core::uuid::Uuid;
+
+use crate::{entities::collection_mints::CollectionMint, AppContext};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Query;
+
+#[Object(name = "MintQuery")]
+impl Query {
+    /// Look up a `collection_mint` by its ID.
+    async fn mint(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<CollectionMint>> {
+        let AppContext {
+            single_collection_mint_loader,
+            ..
+        } = ctx.data::<AppContext>()?;
+
+        single_collection_mint_loader.load_one(id).await
+    }
+}

--- a/api/src/queries/mod.rs
+++ b/api/src/queries/mod.rs
@@ -1,9 +1,19 @@
 #![allow(clippy::unused_async)]
 
+mod collection;
 mod customer;
+mod drop;
+mod mint;
 mod project;
 mod wallet;
 
 // // Add your other ones here to create a unified Query object
 #[derive(async_graphql::MergedObject, Default)]
-pub struct Query(project::Query, wallet::Query, customer::Query);
+pub struct Query(
+    project::Query,
+    wallet::Query,
+    customer::Query,
+    mint::Query,
+    collection::Query,
+    drop::Query,
+);


### PR DESCRIPTION
## Changes
- Query a `collection_mint` by ID on the root query
- Mark project.drop and project.collection fields as depreciated
- Query `drop` and `collection` by ID on the root query
- Add some doc comments for update_mint and retry_update_mint