### PR TITLE
Update Mint Validate Mint isn't an Edition

### DIFF
--- a/api/src/mutations/mint.rs
+++ b/api/src/mutations/mint.rs
@@ -538,6 +538,10 @@ impl Mutation {
             return Err(Error::new("Mint not created"));
         }
 
+        if mint.edition > 0 {
+            return Err(Error::new("Mint is an edition and cannot be updated"));
+        }
+
         let collection = collection.ok_or(Error::new("Collection not found"))?;
         let blockchain = collection.blockchain;
 


### PR DESCRIPTION
## Changes
- Validate the mint isn't an edition before letting edit go through. Editions can be individauly edited.