### PR TITLE
Speed Up Mint Random Selects

### DIFF
--- a/api/src/entities/collection_mints.rs
+++ b/api/src/entities/collection_mints.rs
@@ -25,6 +25,7 @@ pub struct Model {
     pub credits_deduction_id: Option<Uuid>,
     #[sea_orm(nullable)]
     pub compressed: Option<bool>,
+    pub random_pick: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -435,6 +435,7 @@ impl Processor {
                 .map_err(ProcessorErrorKind::InvalidSellerFee)?),
             credits_deduction_id: Set(None),
             compressed: Set(Some(compressed)),
+            ..Default::default()
         };
 
         let mint_model = mint_am.insert(self.db.get()).await?;

--- a/api/src/mutations/mint.rs
+++ b/api/src/mutations/mint.rs
@@ -7,11 +7,7 @@ use hub_core::{
     producer::Producer,
 };
 use redis::AsyncCommands;
-use sea_orm::{
-    prelude::*,
-    sea_query::{Func, SimpleExpr},
-    JoinType, Order, QueryOrder, QuerySelect, Set, TransactionTrait,
-};
+use sea_orm::{prelude::*, JoinType, Order, QueryOrder, QuerySelect, Set, TransactionTrait};
 
 use super::collection::{
     fetch_owner, validate_creators, validate_json, validate_solana_creator_verification,
@@ -1176,7 +1172,7 @@ impl Mutation {
         let mint = CollectionMints::find()
             .filter(collection_mints::Column::CollectionId.eq(drop.collection_id))
             .filter(collection_mints::Column::CreationStatus.eq(CreationStatus::Queued))
-            .order_by(SimpleExpr::FunctionCall(Func::random()), Order::Asc)
+            .order_by(collection_mints::Column::RandomPick, Order::Asc)
             .one(conn)
             .await?
             .ok_or(Error::new("No Queued mint found for the drop"))?;
@@ -1355,7 +1351,7 @@ impl Mutation {
             )
             .filter(collection_mints::Column::CollectionId.eq(drop.collection_id))
             .filter(collection_mints::Column::CreationStatus.eq(CreationStatus::Queued))
-            .order_by(SimpleExpr::FunctionCall(Func::random()), Order::Asc)
+            .order_by(collection_mints::Column::RandomPick, Order::Asc)
             .limit(Some(batch_size.try_into()?))
             .all(conn)
             .await?;

--- a/api/src/objects/collection_mint.rs
+++ b/api/src/objects/collection_mint.rs
@@ -148,6 +148,7 @@ impl From<Model> for CollectionMint {
             seller_fee_basis_points,
             credits_deduction_id,
             compressed,
+            ..
         }: Model,
     ) -> Self {
         Self {

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -61,6 +61,7 @@ mod m20230914_154759_add_job_trackings_table;
 mod m20230915_111128_create_mints_creation_status_idx;
 mod m20230922_150621_nullable_metadata_jsons_identifier_and_uri;
 mod m20231011_202917_create_queued_mints_idx;
+mod m20231020_123046_add_random_pick_to_collection_mints;
 
 pub struct Migrator;
 
@@ -125,10 +126,11 @@ impl MigratorTrait for Migrator {
             Box::new(m20230910_204731_add_queued_variant_to_mints_status::Migration),
             Box::new(m20230910_212742_make_owner_address_optional_for_mint::Migration),
             Box::new(m20230911_144938_make_compressed_column_optional::Migration),
-            Box::new(m20230915_111128_create_mints_creation_status_idx::Migration),
             Box::new(m20230914_154759_add_job_trackings_table::Migration),
+            Box::new(m20230915_111128_create_mints_creation_status_idx::Migration),
             Box::new(m20230922_150621_nullable_metadata_jsons_identifier_and_uri::Migration),
             Box::new(m20231011_202917_create_queued_mints_idx::Migration),
+            Box::new(m20231020_123046_add_random_pick_to_collection_mints::Migration),
         ]
     }
 }

--- a/migration/src/m20231020_123046_add_random_pick_to_collection_mints.rs
+++ b/migration/src/m20231020_123046_add_random_pick_to_collection_mints.rs
@@ -1,0 +1,55 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(CollectionMints::RandomPick)
+                            .big_integer()
+                            .not_null()
+                            .default(Expr::cust(
+                                "(floor(random() * 9223372036854775807))::bigint",
+                            )),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                IndexCreateStatement::new()
+                    .name("collection-mints-random_pick-idx")
+                    .table(CollectionMints::Table)
+                    .col((CollectionMints::RandomPick, IndexOrder::Asc))
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .drop_column(CollectionMints::RandomPick)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+enum CollectionMints {
+    Table,
+    RandomPick,
+}


### PR DESCRIPTION
## Changes
- Add `random_pick` column to collection mints that defaults to random big int
- Add index on random_pick
- When picking random mint use the random_pick so index can be used for faster select