### PR TITLE
Remove Supply Increment on Queue Mint To Drop

### DIFF
--- a/api/src/mutations/mint.rs
+++ b/api/src/mutations/mint.rs
@@ -899,15 +899,6 @@ impl Mutation {
 
         let tx: sea_orm::DatabaseTransaction = conn.begin().await?;
 
-        collections::Entity::update_many()
-            .col_expr(
-                collections::Column::Supply,
-                Expr::value(Expr::col(collections::Column::Supply).add(Value::Int(Some(1)))),
-            )
-            .filter(collections::Column::Id.eq(collection_model.id))
-            .exec(&tx)
-            .await?;
-
         let mint = collection_mints::ActiveModel {
             collection_id: Set(drop.collection_id),
             owner: Set(None),


### PR DESCRIPTION
## Changes
- Dont update supply on queued mint to drop because its calculated in dataloader and then cached